### PR TITLE
feat: 環境変数を導入し、APIのURLを外部設定化

### DIFF
--- a/next-app/.env.development
+++ b/next-app/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8081

--- a/next-app/.gitignore
+++ b/next-app/.gitignore
@@ -30,8 +30,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
+# Environment variables
+# env files
+.env*.local
 
 # vercel
 .vercel

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -18,7 +18,8 @@ export default function Home() {
   useEffect(() => {
     const fetchHarvests = async () => {
       try {
-        const response = await fetch('http://localhost:8081/api/harvests');
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
+        const response = await fetch(`${apiUrl}/api/harvests`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }


### PR DESCRIPTION
Next.jsアプリケーションで環境変数を使用できるように設定を追加。

APIのエンドポイントをハードコードするのではなく、.envファイルから読み込むように変更した。

- .env.developmentファイルを追加し、開発用のAPIベースURLを定義

- page.tsxでprocess.env.NEXT_PUBLIC_API_URLを使用してAPIを呼び出すように修正

- .gitignoreを更新し、.env*.localファイルが追跡されないようにした